### PR TITLE
Corrige une typo dans les commentaires sur Koan3UsefulShortcutForRefactoring.kt

### DIFF
--- a/kotlin/src/test/kotlin/Koan3UsefulShortcutForRefactoring.kt
+++ b/kotlin/src/test/kotlin/Koan3UsefulShortcutForRefactoring.kt
@@ -74,9 +74,9 @@ class Koan3UsefulShortcutForRefactoring {
 
     @Test
     fun `06 - change parameter order`() {
-        // invert word1 and word2
-        // Use ⇧⌥⌘← / Ctrl+Shift+Alt+← to navigate back
-        // Use ⇧⌥⌘→ / Ctrl+Shift+Alt+→ to navigate forward
+        // invert word1 and word2 parameters
+        // Use ⇧⌥⌘← / Ctrl+Shift+Alt+← to move element left
+        // Use ⇧⌥⌘→ / Ctrl+Shift+Alt+→ to move element right
         fun say2Words(word1: String, word2: String): String {
             return word1 + word2
         }


### PR DESCRIPTION
Hello,
Ça ressemble à un copié/collé de Koan1BasicsNavigateSelectionAndDeletion#12 - Navigate back and forward, le nom de l'action dans le menu est "Move element left/right" j'ai repris ce nommage.